### PR TITLE
Check if the respone is 204 (No Content) and raise an exception.

### DIFF
--- a/lib/virustotal_api/base.rb
+++ b/lib/virustotal_api/base.rb
@@ -1,3 +1,5 @@
+require 'virustotal_api/exceptions'
+
 require 'rest-client'
 require 'json'
 
@@ -6,6 +8,16 @@ module VirustotalAPI
     # @return [String] string of API URI class method
     def self.api_uri
       VirustotalAPI::URI
+    end
+
+    # @param [RestClient::Response] response
+    # @return [Hash] the parsed JSON.
+    def self.parse(response)
+      if response.code == 204
+        raise(RateLimitError,"maximum number of 4 requests per minute reached")
+      end
+
+      JSON.parse(response.body)
     end
 
     # @return [String] string of API URI instance method

--- a/lib/virustotal_api/base.rb
+++ b/lib/virustotal_api/base.rb
@@ -14,7 +14,7 @@ module VirustotalAPI
     # @return [Hash] the parsed JSON.
     def self.parse(response)
       if response.code == 204
-        raise(RateLimitError,"maximum number of 4 requests per minute reached")
+        fail(RateLimitError, 'maximum number of 4 requests per minute reached')
       end
 
       JSON.parse(response.body)

--- a/lib/virustotal_api/domain_report.rb
+++ b/lib/virustotal_api/domain_report.rb
@@ -17,7 +17,7 @@ module VirustotalAPI
         api_uri + '/domain/report',
         { :params => params(domain, api_key) }
       )
-      report = JSON.parse(response.body)
+      report = parse(response)
 
       new(report)
     end

--- a/lib/virustotal_api/exceptions.rb
+++ b/lib/virustotal_api/exceptions.rb
@@ -1,0 +1,4 @@
+module VirustotalAPI
+  class RateLimitError < RuntimeError
+  end
+end

--- a/lib/virustotal_api/file_report.rb
+++ b/lib/virustotal_api/file_report.rb
@@ -18,7 +18,7 @@ module VirustotalAPI
         api_uri + '/file/report',
         params(resource, api_key)
       )
-      report = JSON.parse(response.body)
+      report = parse(response)
 
       new(report)
     end

--- a/lib/virustotal_api/ip_report.rb
+++ b/lib/virustotal_api/ip_report.rb
@@ -17,7 +17,7 @@ module VirustotalAPI
         api_uri + '/ip-address/report',
         { :params => params(ip, api_key) }
       )
-      report = JSON.parse(response.body)
+      report = parse(response)
 
       new(report)
     end

--- a/lib/virustotal_api/url_report.rb
+++ b/lib/virustotal_api/url_report.rb
@@ -19,7 +19,7 @@ module VirustotalAPI
         api_uri + '/url/report',
         params(resource, api_key)
       )
-      report = JSON.parse(response.body)
+      report = parse(response)
 
       new(report)
     end


### PR DESCRIPTION
* VirusTotal only allows 4 queries per minute for their Public API.
  https://www.virustotal.com/en/faq/
* Raise a RateLimitError exception to notify the user.
* DRY up calls to `JSON.parse` by adding `Base.parse`.