### PR TITLE
Add optional scan param for url report API

### DIFF
--- a/lib/virustotal_api/url_report.rb
+++ b/lib/virustotal_api/url_report.rb
@@ -13,11 +13,12 @@ module VirustotalAPI
 
     # @param [String] resource file as a md5/sha1/sha256 hash
     # @param [String] api_key for virustotal
+    # @param [Integer] optional param to start scan if not found. 1 for true
     # @return [VirustotalAPI::URLReport] Report Search Result
-    def self.find(resource, api_key)
+    def self.find(resource, api_key, scan = 0)
       response = RestClient.post(
         api_uri + '/url/report',
-        params(resource, api_key)
+        params(resource, api_key, scan)
       )
       report = parse(response)
 
@@ -26,11 +27,13 @@ module VirustotalAPI
 
     # @param [String] resource file as a md5/sha1/sha256 hash
     # @param [String] api_key for virustotal
+    # @param [Integer] optional param to start scan if not found. 1 for true
     # @return [Hash] params for POST Request
-    def self.params(resource, api_key)
+    def self.params(resource, api_key, scan = 0)
       {
         :resource => resource,
-        :apikey   => api_key
+        :apikey   => api_key,
+        :scan     => scan.to_s
       }
     end
   end

--- a/test/fixtures/queue_unscanned_url_report.yml
+++ b/test/fixtures/queue_unscanned_url_report.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.virustotal.com/vtapi/v2/url/report
+    body:
+      encoding: UTF-8
+      string: resource=http%3A%2F%2Fwww.unscanned.com&apikey=testapikey&scan=1
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '119'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - www.virustotal.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      X-Cloud-Trace-Context:
+      - 82dde70aa4bad5b45d047d625ec37c2a
+      Date:
+      - Thu, 15 Mar 2018 14:46:41 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '441'
+    body:
+      encoding: UTF-8
+      string: '{"permalink": "https://www.virustotal.com/url/c1f6493ad83d51c833a875bb10cca5bde7e2c35456168173a0bf25005c43ecaf/analysis/1521125201/",
+        "resource": "http://www.unscanned.com/", "url": "http://www.unscanned.com/",
+        "response_code": 1, "scan_date": "2018-03-15 14:46:41", "scan_id": "c1f6493ad83d51c833a875bb10cca5bde7e2c35456168173a0bf25005c43ecaf-1521125201",
+        "verbose_msg": "Scan request successfully queued, come back later for the
+        report"}'
+    http_version:
+  recorded_at: Thu, 15 Mar 2018 14:46:41 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/unscanned_url_report.yml
+++ b/test/fixtures/unscanned_url_report.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.virustotal.com/vtapi/v2/url/report
+    body:
+      encoding: UTF-8
+      string: resource=http%3A%2F%2Fwww.unscanned.com&apikey=testapikey&scan=1
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - www.virustotal.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      X-Cloud-Trace-Context:
+      - c84c4f4eb1779a0f9dc92289b5c1c038
+      Date:
+      - Thu, 15 Mar 2018 14:45:55 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '439'
+    body:
+      encoding: UTF-8
+      string: '{"permalink": "https://www.virustotal.com/url/70c70c5c65bfd7fa317c625e7c5c020275b56b2cb6e8017b44f568c56b7794a1/analysis/1521125155/",
+        "resource": "http://www.unscanned.com/", "url": "http://www.unscanned.com/",
+        "response_code": 1, "scan_date": "2018-03-15 14:45:55", "scan_id": "70c70c5c65bfd7fa317c625e7c5c020275b56b2cb6e8017b44f568c56b7794a1-1521125155",
+        "verbose_msg": "Scan request successfully queued, come back later for the
+        report"}'
+    http_version:
+  recorded_at: Thu, 15 Mar 2018 14:45:55 GMT
+recorded_with: VCR 4.0.0

--- a/test/url_report_test.rb
+++ b/test/url_report_test.rb
@@ -3,6 +3,7 @@ require './test/test_helper'
 
 class VirustotalAPIURLReportTest < Minitest::Test
   def setup
+    @unscanned_url = 'http://www.unscanned.com'
     @url     = 'http://www.google.com'
     @api_key = 'testapikey'
   end
@@ -34,6 +35,22 @@ class VirustotalAPIURLReportTest < Minitest::Test
       vturl_report = VirustotalAPI::URLReport.find(@url, @api_key)
 
       assert vturl_report.scan_id.is_a?(String)
+    end
+  end
+
+  def test_scan_unscanned_url
+    VCR.use_cassette('unscanned_url_report') do
+      vturl_report = VirustotalAPI::URLReport.find(@unscanned_url, @api_key)
+
+      assert vturl_report.report['response_code'] == 0
+    end
+  end
+
+  def test_scan_unscanned_url
+    VCR.use_cassette('queue_unscanned_url_report') do
+      vturl_report = VirustotalAPI::URLReport.find(@unscanned_url, @api_key, 1)
+
+      assert vturl_report.report['response_code'] == 1
     end
   end
 end


### PR DESCRIPTION
The url report API accepts an optional parameter of `scan`, which, if set to `1` will queue a scan of the submitted URL.
This adds the possibility of queuing a scan for urls