### PR TITLE
base: use strict_encode in base64 encoding.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1.46.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # VirusTotal API Changelog
 
+## [0.5.4] - 2020-12-10
+* Manage bad requests like not found
+* Use strict base64 encoding
+  * [@crondaemon](https://github.com/crondaemon)
+
+## [0.5.3] = 2020-10-12
+
 ## [0.5.2] - 2020-10-06
 
 * Fix Fix exists? check

--- a/lib/virustotal_api/base.rb
+++ b/lib/virustotal_api/base.rb
@@ -37,7 +37,7 @@ module VirustotalAPI
         payload: options
       )
       JSON.parse(response.body)
-    rescue RestClient::NotFound
+    rescue RestClient::NotFound, RestClient::BadRequest
       {}
     rescue RestClient::Unauthorized
       # Raise a custom exception not to expose the underlying

--- a/lib/virustotal_api/base.rb
+++ b/lib/virustotal_api/base.rb
@@ -62,7 +62,7 @@ module VirustotalAPI
     # Generate a URL identifier.
     # @see https://developers.virustotal.com/v3.0/reference#url
     def self.url_identifier(url)
-      Base64.encode64(url).strip.gsub('=', '')
+      Base64.strict_encode64(url).strip.gsub('=', '')
     end
   end
 end

--- a/lib/virustotal_api/version.rb
+++ b/lib/virustotal_api/version.rb
@@ -2,5 +2,5 @@
 
 module VirustotalAPI
   # The GEM version
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -4,6 +4,7 @@ require './test/test_helper'
 
 class VirustotalAPIBaseTest < Minitest::Test
   def setup
+    @domain  = 'xpressco.za'
     @sha256  = '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b'
     @api_key = 'testapikey'
   end
@@ -40,6 +41,12 @@ class VirustotalAPIBaseTest < Minitest::Test
   def test_not_exists?
     VCR.use_cassette('file_not_found') do
       virustotal_report = VirustotalAPI::File.find(@sha256, @api_key)
+
+      assert !virustotal_report.exists?
+    end
+
+    VCR.use_cassette('domain_bad_request') do
+      virustotal_report = VirustotalAPI::Domain.find(@domain, @api_key)
 
       assert !virustotal_report.exists?
     end

--- a/test/fixtures/domain_bad_request.yml
+++ b/test/fixtures/domain_bad_request.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.virustotal.com/api/v3/domains/xpressco.za
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.1p57
+      X-Apikey:
+      - testapikey
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - www.virustotal.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Cloud-Trace-Context:
+      - f9f5f005efc95b0390a91fb6306201d6
+      Date:
+      - Mon, 28 Dec 2020 13:56:50 GMT
+      Server:
+      - Google Frontend
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "error": {
+                "code": "InvalidArgumentError",
+                "message": "Domain \"xpressco.za\" is not a valid domain pattern"
+            }
+        }
+    http_version: 
+  recorded_at: Mon, 28 Dec 2020 13:56:50 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
This prevents the newline to cause errors.