### PR TITLE
Drop ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,25 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  Test-Ruby-2-5:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1.70.1
-      with:
-        ruby-version: 2.5
-    - name: Show Ruby Version
-      run: ruby --version
-    - name: Install dependencies
-      run: bundle install
-    - name: Lint
-      run: bundle exec rake rubocop
-    - name: Run tests
-      run: bundle exec rake
-      
   Test-Ruby-2-7:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # VirusTotal API Changelog
 
+## [0.5.7] - 2021-09-20
+
+* Remove eol ruby 2.5
+  * [@jonnynux](https://github.com/jonnynux)
+
 ## [0.5.5] - 2021-05-10
+
 * Add support for larger files
   * [@Grandman](https://github.com/Grandman)
 
 ## [0.5.4] - 2020-12-10
+
 * Manage bad requests like not found
 * Use strict base64 encoding
   * [@crondaemon](https://github.com/crondaemon)

--- a/virustotal_api.gemspec
+++ b/virustotal_api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/pwelch/virustotal_api'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
CHANGELOG: Deprecated

## Summary
Remove EOL ruby 2.5

## Testing

No tests needed.

To rebase after #38.