### PR TITLE
Add Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1.110.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
     - name: Show Ruby Version
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1.110.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
     - name: Show Ruby Version
@@ -52,9 +52,28 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      uses: ruby/setup-ruby@v1.110.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
+    - name: Show Ruby Version
+      run: ruby --version
+    - name: Install dependencies
+      run: bundle install
+    - name: Lint
+      run: bundle exec rake rubocop
+    - name: Run tests
+      run: bundle exec rake
+      
+  Test-Ruby-3-2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
     - name: Show Ruby Version
       run: ruby --version
     - name: Install dependencies


### PR DESCRIPTION
CHANGELOG: Added Ruby 3.2 Testing

## Summary

- Add Ruby 3.2 to test matrix
- Switch to `ruby/setup-ruby@v1` as the preferred syntax for Ruby Actions: https://github.com/ruby/setup-ruby#versioning
